### PR TITLE
Serverless Environment Variables

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,0 +1,7 @@
+module.exports = {
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  user: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME
+};

--- a/config/db_template.js
+++ b/config/db_template.js
@@ -1,6 +1,0 @@
-module.exports = {
-	database: 'TODO',
-	host: 'TODO',
-	port: 'TODO',
-	user: 'TODO'
-}

--- a/handler.js
+++ b/handler.js
@@ -1,13 +1,12 @@
 const db = require('./db_connect');
 const request = require('request');
-const key = 'IDLDIAQZL3ZV2GGZWD5TNDDTF3YPPPEE';
+const key = process.env.API_KEY;
 
 module.exports.getBars = (event, context, callback) => {
   const symbol = event.pathParameters.symbol;
   const apiUrl = `https://api.tdameritrade.com/v1/marketdata/${symbol}/pricehistory?apikey=${key}&periodType=year&period=1&frequencyType=weekly&frequency=1`;
 
   context.callbackWaitsForEmptyEventLoop = false;
-
   request.get(apiUrl, (error, response, body) => {
     if (error) {
       console.log(error);
@@ -20,7 +19,7 @@ module.exports.getBars = (event, context, callback) => {
         body
       })
     } else {
-      callback(`Error processing request to TD Ameritrade API, returned status code: ${response.statusCode}`)
+      callback(`Error processing request to TD Ameritrade API, returned status code: ${response.statusCode} for URI: ${apiUrl}`)
     }
   })
 };

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,12 +22,23 @@ org: kumprj
 plugins:
   - serverless-offline
 
+custom:
+  DB_CREDENTIALS: ${ssm:/aws/reference/secretsmanager/stocksDatabaseLogin~true}
+  API_KEY: ${ssm:/aws/reference/secretsmanager/tdAmeritradeApiKey~true}
+
 provider:
   name: aws
   runtime: nodejs10.x
   memorySize: 128
   timeout: 30
   region: us-east-2
+  environment:
+    DB_PASSWORD: ${self:custom.DB_CREDENTIALS.password}
+    DB_USERNAME: ${self:custom.DB_CREDENTIALS.username}
+    DB_HOST: ${self:custom.DB_CREDENTIALS.host}
+    DB_PORT: ${self:custom.DB_CREDENTIALS.port}
+    DB_NAME: ${self:custom.DB_CREDENTIALS.dbname}
+    API_KEY: ${self:custom.API_KEY.TD_API_KEY}
 # you can overwrite defaults here
 #  stage: dev
 #  region: us-east-1


### PR DESCRIPTION
Set up AWS Secret Manager to store our API Key and db credentials. serverless.yml now pulls those values and stores them as environment variables. Should allow for CI with github.